### PR TITLE
[FIX] 헤드헌트 이력서에 memberId 대신 사용자 이름 표시

### DIFF
--- a/src/main/java/com/project/careerfair/domain/Resume.java
+++ b/src/main/java/com/project/careerfair/domain/Resume.java
@@ -17,6 +17,7 @@ public class Resume {
     private String lastUpdated;
 
     private String memberId;
+    private String memberName;
     private Integer industryId;
 
 }

--- a/src/main/resources/com/project/careerfair/mapper/resume/ResumeMapper.xml
+++ b/src/main/resources/com/project/careerfair/mapper/resume/ResumeMapper.xml
@@ -8,6 +8,7 @@
         <id column="resume_id" property="resumeId"/>
         <result column="title" property="title" />
         <result column="member_id" property="memberId" />
+        <result column="name" property="memberName" />
         <result column="military" property="military" />
         <result column="intro" property="intro" />
         <result column="industry_id" property="industryId" />
@@ -345,8 +346,18 @@
     </select>
 
     <select id="findAllByIndustry" resultMap="resumeData">
-        SELECT *
+        SELECT
+            tr.resume_id,
+            tr.title,
+            tr.military,
+            tr.intro,
+            tr.created,
+            tr.last_updated,
+            tr.member_id,
+            tm.name,
+            tr.industry_id
         FROM TB_ONLINE_RESUME tr
+        LEFT JOIN TB_MEMBERS tm ON tr.member_id = tm.member_id
         <where>
             <if test="industries neq null">
                 AND tr.industry_id IN

--- a/src/main/webapp/WEB-INF/views/resume/scout.jsp
+++ b/src/main/webapp/WEB-INF/views/resume/scout.jsp
@@ -93,7 +93,7 @@
         <c:forEach items="${resumeList}" var="resume">
             <div class="list-group-item">
                 <a class="mb-1" href="/resume/${resume.resumeId}">${resume.title}</a>
-                <p class="mb-1">${resume.memberId}</p>
+                <p class="mb-1">${resume.memberName}</p>
             </div>
         </c:forEach>
     </div>


### PR DESCRIPTION
- 이름 항목에 실제 memberId가 표시되던 현상 수정